### PR TITLE
docs(readme): add step to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Run these commands in your terminal to get yourself setup:
 ```
 git clone https://github.com/kentcdodds/react-testing-library-course.git --branch workshop-2018-09
 cd react-testing-library-course/
+npm install
 npm run setup
 ```
 


### PR DESCRIPTION
Not sure if this problem is specific to my Windows 10 machine, but I had to run `npm i` before `npm run setup` would work while following the setup instructions in Readme.md. Setup depends on Inquirer.