### PR TITLE
Update hidden-message.js so basic tests can pass without mocking

### DIFF
--- a/src/hidden-message.js
+++ b/src/hidden-message.js
@@ -3,7 +3,7 @@ import {CSSTransition} from 'react-transition-group'
 
 function Fade({children, ...props}) {
   return (
-    <CSSTransition {...props} timeout={1000} className="fade">
+    <CSSTransition {...props} unmountOnExit timeout={1000} className="fade">
       {children}
     </CSSTransition>
   )


### PR DESCRIPTION
By default, a CSSTransition will stay mounted in the 'exited' state. Need to include the `unmountOnExit` prop to remove it from the DOM.