### PR TITLE
removing unnessary spread

### DIFF
--- a/src/__tests__/react-router-03.js
+++ b/src/__tests__/react-router-03.js
@@ -16,14 +16,12 @@ function render(ui, {route = '/', ...renderOptions} = {}) {
     // is actually easier anyway.
     return <BrowserRouter>{children}</BrowserRouter>
   }
-  return {
-    ...rtlRender(ui, {
-      wrapper: Wrapper,
-      ...renderOptions,
-      // originally this exposed history, but that's really
-      // an implementation detail, so we don't recommend that anymore
-    }),
-  }
+  return rtlRender(ui, {
+    wrapper: Wrapper,
+    ...renderOptions,
+    // originally this exposed history, but that's really
+    // an implementation detail, so we don't recommend that anymore
+  })
 }
 
 test('main renders about and home and I can navigate to those pages', () => {


### PR DESCRIPTION
Since history is not being exposed anymore, there is no need to spread the return object here. This could potentially lead to a misunderstanding that spreading the return is always necessary when creating a custom render