### PR TITLE
update to fix forced fail tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -93,7 +93,7 @@ function Confirm({history}) {
         history.push('/success')
       },
       (error) => {
-        history.push('/error', {state: {error}})
+        history.push('/error', {error})
       },
     )
   }


### PR DESCRIPTION
When working on lesson 41 for Test React Components with Jest and React Testing Library, if you create a test that Rejects the value once, the test will fail with an error of `TypeError: Cannot read property 'message' of undefined`.

![Screen Shot 2022-09-08 at 3 33 33 PM](https://user-images.githubusercontent.com/26470581/189237695-23e47a85-612a-49a1-a7ec-35af878028db.png)

This is the test: 
```js
test('Show error if exist', async () => {
  mockSubmitForm.mockRejectedValueOnce({message: 'testError'})
  const testData = {food: 'test food', drink: 'test drink'}
  render(<App />)

  userEvent.click(await screen.findByText(/fill.*form/i))

  userEvent.type(await screen.findByLabelText(/food/i), testData.food)
  userEvent.click(await screen.findByText(/next/i))

  userEvent.type(await screen.findByLabelText(/drink/i), testData.drink)
  userEvent.click(await screen.findByText(/review/i))

  expect(await screen.findByLabelText(/food/i)).toHaveTextContent(testData.food)
  expect(await screen.findByLabelText(/drink/i)).toHaveTextContent(
    testData.drink,
  )

  userEvent.click(await screen.findByText(/confirm/i, {selector: 'button'}))

  expect(mockSubmitForm).toHaveBeenCalledWith(testData)
  expect(mockSubmitForm).toHaveBeenCalledTimes(1)

  userEvent.click(await screen.findByText(/home/i))

  expect(await screen.findByText(/welcome home/i)).toBeInTheDocument()
})
```

If you update `history.push('/error', {state: {error}})` to `history.push('/error', {error})` on line 96 in app.js, it fixes this error. 